### PR TITLE
Big refactor

### DIFF
--- a/src/filter.jl
+++ b/src/filter.jl
@@ -1,20 +1,33 @@
-macro filter(input::Symbol, ex::Expr...)
-    # local lex = QuoteNode(ex)
-    conds = [ QueryArg(cond) for cond in ex ]
+macro filter(input::Symbol, conds::Expr...)
+    g = _filter(input, collect(conds))
+    f, fdef, fields = resolve(g)
+    #= we need to generate the filtering kernel's definition at macroexpand-time
+    so it can be spliced into the proper (i.e., original caller's) scope =#
     return quote
-        run(filter($(esc(input)), $conds))
+        $f = $fdef
+        run($(esc(input)), $g, $f, $fields)
     end
 end
 
-macro filter(ex::Expr...)
-    conds = [ QueryArg(cond) for cond in ex ]
+# for case in which data source is piped to @filter call
+macro filter(conds::Expr...)
+    g = _filter(gensym(), collect(conds))
+    f, fdef, fields = resolve(g)
     return quote
-        run(filter($conds))
+        $f = $fdef
+        run($g, $f, $fields)
     end
 end
 
-Base.filter(conds::Vector{QueryArg{Expr}}) = x -> filter(x, conds)
-Base.filter(input::DataFrame, conds::Vector{QueryArg{Expr}}) =
-    FilterNode(DataNode(input), collect(conds))
-Base.filter(input::QueryNode, conds::Vector{QueryArg{Expr}}) =
-    FilterNode(input, conds)
+_filter(conds) = x -> _filter(x, conds)
+_filter(input, conds) = FilterNode(input, conds)
+
+run(g::FilterNode, f, fields) = x -> run(x, g, f, fields)
+# wrap in if statement so I don't have to load DataFrames everytime I reload this module
+if isdefined(Main, :DataFrame)
+    function run(df::Main.DataFrames.DataFrame, g::FilterNode, f, fields)
+        cols = [ df[field] for field in fields ]
+        rows = bitbroadcast(f, cols...)
+        df[rows, :]
+    end
+end

--- a/src/jplyr.jl
+++ b/src/jplyr.jl
@@ -1,11 +1,18 @@
 module jplyr
+# using RDatasets
+# using DataFrames
 
-export @query, @filter, @select
-export DataFrame # test purposes
+
+export @query,
+    @filter,
+    @select,
+    # following are exported only for test purposes
+    resolve
 
 include("querynode.jl")
 include("query.jl")
 include("select.jl")
 include("filter.jl")
+include("resolve.jl")
 
 end # module

--- a/src/querynode.jl
+++ b/src/querynode.jl
@@ -1,22 +1,19 @@
-type DataFrame end
-
 abstract QueryNode
 
-immutable DataNode{T} <: QueryNode
-    data::T
+immutable DataNode <: QueryNode
+    input::Symbol
 end
-
-QueryNode(df::DataFrame) = DataNode(df)
 
 immutable FilterNode <: QueryNode
     input::QueryNode
     conds::Vector{Expr}
 end
 
-FilterNode(input, ex::Expr...) = FilterNode(input, collect(ex))
-FilterNode(input::DataFrame, ex::Expr...) = FilterNode(DataNode(input), collect(ex))
+FilterNode(input::Symbol, conds) = FilterNode(DataNode(input), conds)
 
 immutable SelectNode <: QueryNode
     input::QueryNode
-    cols::Vector{Symbol}
+    fields::Vector{Symbol}
 end
+
+SelectNode(input::Symbol, cols) = SelectNode(DataNode(input), cols)

--- a/src/resolve.jl
+++ b/src/resolve.jl
@@ -1,0 +1,53 @@
+#=
+- resolve scope of symbols in QueryNode data fields (e.g. in FilterNode
+conditions)
+- Is essentially Simon Byrne's scopefun! implementation from
+https://gist.github.com/simonbyrne/30522225543b86f3f20e084220c2f485
+=#
+
+function resolve(g::FilterNode)
+    fields, _conds = resolve(g.conds)
+    cond = aggr(_conds)
+    fdef = Expr(:->, Expr(:tuple, fields...), cond)
+    return gensym("f"), fdef, fields
+end
+
+function resolve(conds)
+    cols = Set{Symbol}()
+    _conds = [ resolve!(cond, cols) for cond in conds ]
+    return cols, _conds
+end
+
+resolve!(x, cols) = x
+function resolve!(sym::Symbol, cols)
+    push!(cols, sym)
+    return sym
+end
+
+function resolve!(ex::Expr, cols)
+    if ex.head == :$
+        return ex.args[1]
+    elseif ex.head == :call
+        return Expr(:call, exf(ex), [ resolve!(arg, cols) for arg in exfargs(ex) ]...)
+    elseif ex.head == :comparison
+        return Expr(:comparison, resolve!(ex.args[1], cols), ex.args[2], resolve!(ex.args[3], cols))
+    else
+        return Expr([ resolve!(arg, cols) for arg in ex.args ]...)
+    end
+end
+
+# aggregate filter conditions into a single expression
+function aggr(_conds)
+    len = length(_conds)
+    if len == 1
+        res = _conds[1]
+    else
+        res = :($(_conds[1]) & $(_conds[2]))
+        if len > 2
+            for i in 3:len
+                res = :($res & $(_conds[i]))
+            end
+        end
+    end
+    return res
+end


### PR DESCRIPTION
In the original conception of this package as described in https://github.com/davidagold/jplyr.jl/blob/a3298a35ce89ccc145947298ae42a650f73ea3c7/README.md, query graphs were created at run-time in order to contain information about the types of the data sources passed to manipulation commands. However, this created a problem with respect to `filter`. The strategy for lowering (word choice?) `@filter(df, field > value)` for `df::DataFrame` is to generate a "filter kernel" `x -> x > value` and `map` (or `bitbroadcast`) it over `df[:field]` to obtain the row indices of the desired observations. However, if one is to allow variables in filter expressions, then one needs to make sure that the kernel is defined in the same scope as the variables, and this necessitates splicing the definition of the kernel into the call site of `@filter`/`@query`. In turn, this means that, for the graphs to be useful, they must be generated at macroexpand-time. This PR introduces this change.

Of course, the trade-off here is that we don't know the type of the data source at macroexpand-time, and hence we cannot decide to generate a kernel _or_ SQL code based on the type of the data source then. The solution of this PR is to generate and splice the definition of the kernel into the call site in all cases and pass it, along with the data source and the graph, to the `run` function, which in turn dispatches on the type of the data source. If the latter is a `DataFrame`, the kernel is used; if it is a database connection, then `run` will be able to (in the future) pass the graph to some SQL generation method.
