### PR TITLE
Solution to issue #2

### DIFF
--- a/src/groupby.jl
+++ b/src/groupby.jl
@@ -1,7 +1,27 @@
-macro groupby(fields...)
-    g = _groupby(gensym(), collect(fields))
+#=
+@groupby experiences same issue concerning piped and non-piped data inputs as
+does @select. See top of `src/select.jl` for details and current solution
+=#
+macro groupby(args...)
+    # for case where first arg is data input
+    input, cols = args[1], args[2:end]
+    _input = QuoteNode(input)
+    g1 = _groupby(input, collect(cols))
+    # for case where all args are column specifications
+    g2 = _groupby(gensym(), collect(args))
     return quote
-        run($g)
+        try # assume first that first arg is data input
+            run($(esc(input)), $g1)
+        catch err
+            #= if error because first arg isn't valid name, assume it is a
+            column specification and return curried run. Otherwise, throw
+            the error =#
+            if err == UndefVarError($_input)
+                run($g2)
+            else
+                throw(err)
+            end
+        end
     end
 end
 

--- a/src/select.jl
+++ b/src/select.jl
@@ -1,13 +1,34 @@
 #=
-TO DO: figure out how to differentiate b/w piped to and non-piped to
-@select calls. Currently, only the former are handled. The issue is how to
-distinguish a symbol that represents a data source argument from a symbol
-that represents a field name argument
+OPEN QUESTION: How to differentiate b/w piped to and non-piped to
+@select calls. The issue is how to distinguish a symbol that represents a
+data source argument from a symbol that represents a column specification.
+The following is one way to do so. However, this strategy will fail/give
+incorrect results in cases such as the following:
+
+df |> @select(fieldname)
+
+where `df` and `fieldname` are both valid names bound to DataFrame objects.
 =#
-macro select(syms...)
-    g = _select(gensym(), collect(syms))
+macro select(args...)
+    # for case where first arg is data input
+    input, cols = args[1], args[2:end]
+    _input = QuoteNode(input)
+    g1 = _select(input, collect(cols))
+    # for case where all args are column specifications
+    g2 = _select(gensym(), collect(args))
     return quote
-        run($g)
+        try # assume first that first arg is data input
+            run($(esc(input)), $g1)
+        catch err
+            #= if error because first arg isn't valid name, assume it is a
+            column specification and return curried run. Otherwise, throw
+            the error =#
+            if err == UndefVarError($_input)
+                run($g2)
+            else
+                throw(err)
+            end
+        end
     end
 end
 


### PR DESCRIPTION
This PR introduces a strategy for supporting both piped-to and non-piped-to versions of `@select` and `@groupby`. The difficulty in doing so is described in #2 -- essentially, there's no way (at macroexpand time) to distinguish the difference between an argument signature that includes a data source and an argument signature that doesn't. The solution introduced here produces a graph for each possible case and splices in a `try-catch` block that first tries `run`ing the input and the first graph, i.e. the one produced under the assumption that a data input has been passed. If a data source has in fact not been passed, then we assume the `run` call will fail with an `UndefVarError`. If this is the case, we fall back on `run`ing the second graph.

At this point in time I prefer the present solution to the possibilities 1-4 originally described in #2. However, there are costs/downsides to this approach. The first is that it relies on handling exceptions, and this may introduce performance penalties (I'm not sure). If this is true, I don't think they'll be substantial, unless one includes `@select`/`@groupby` commands in an inner loop -- and we can suggest to folks not to do this (producing a graph via `@query` doesn't experience this problem since it can "see" the entire command pipeline, and hence could be used instead in this (unlikely?) use case). The second point is that this method will fail in cases such as 

``` julia
df |> @select(fieldname)
```

where `df` and `fieldname` are both valid names in the caller's scope and are both bound to `DataFrame` objects.

Right now, I think these costs outweigh the benefits of this solution. So, I'm merging this, and leaving this discussion for posterity. 
