### PR TITLE
Refactor

### DIFF
--- a/src/filter.jl
+++ b/src/filter.jl
@@ -1,30 +1,34 @@
-macro filter(input::Symbol, conds::Expr...)
-    g = _filter(input, collect(conds))
-    f, fdef, fields = resolve(g)
+macro filter(input::Symbol, _conds::Expr...)
+    # g = _filter(input, collect(conds))
+    conds = collect(_conds)
+    f, fdef, fields = resolve_filter(conds)
     #= we need to generate the filtering kernel's definition at macroexpand-time
-    so it can be spliced into the proper (i.e., original caller's) scope =#
+    so the definition can be spliced into the proper (i.e., original caller's) scope =#
     return quote
         $f = $fdef
-        run($(esc(input)), $g, $f, $fields)
+        hlpr = FilterHelper($f, $fields)
+        g = FilterNode($(esc(input)), $conds, hlpr)
+        return run(g.input, g)
     end
 end
 
 # for case in which data source is piped to @filter call
-macro filter(conds::Expr...)
-    g = _filter(gensym(), collect(conds))
-    f, fdef, fields = resolve(g)
+macro filter(_conds::Expr...)
+    conds = collect(_conds)
+    f, fdef, fields = resolve_filter(conds)
     return quote
         $f = $fdef
-        run($g, $f, $fields)
+        hlpr = FilterHelper($f, $fields)
+        g = FilterNode(gensym(), $conds, hlpr)
+        return run(CurryNode(), g)
     end
 end
 
-_filter(conds) = x -> _filter(x, conds)
-_filter(input, conds) = FilterNode(input, conds)
-
-run(g::FilterNode, f, fields) = x -> run(x, g, f, fields)
-function run(df::DataFrames.DataFrame, g::FilterNode, f, fields)
-    cols = [ df[field] for field in fields ]
-    rows = bitbroadcast(f, cols...)
-    df[rows, :]
+run(::CurryNode, g::FilterNode) = x -> run(x, g)
+run(input::DataNode, g::FilterNode) = run(input.input, g)
+function run(df::DataFrames.DataFrame, g::FilterNode)
+    hlpr = g.hlpr
+    cols = [ df[field] for field in hlpr.fields ]
+    rows = bitbroadcast(hlpr.kernel, cols...)
+    return df[rows, :]
 end

--- a/src/groupby.jl
+++ b/src/groupby.jl
@@ -3,21 +3,19 @@
 does @select. See top of `src/select.jl` for details and current solution
 =#
 macro groupby(args...)
-    # for case where first arg is data input
     input, cols = args[1], args[2:end]
     _input = QuoteNode(input)
-    g1 = _groupby(input, collect(cols))
-    # for case where all args are column specifications
-    g2 = _groupby(gensym(), collect(args))
     return quote
         try # assume first that first arg is data input
-            run($(esc(input)), $g1)
+            g = GroupbyNode($(esc(input)), collect($cols))
+            run(g.input, g)
         catch err
             #= if error because first arg isn't valid name, assume it is a
             column specification and return curried run. Otherwise, throw
             the error =#
             if err == UndefVarError($_input)
-                run($g2)
+                g = GroupbyNode(DataNode(), collect($args))
+                run(CurryNode(), g)
             else
                 throw(err)
             end
@@ -25,8 +23,6 @@ macro groupby(args...)
     end
 end
 
-_groupby(conds) = x -> _groupby(x, conds)
-_groupby(input, conds) = GroupbyNode(input, conds)
-
-run(g::GroupbyNode) = x -> run(x, g)
+run(::CurryNode, g::GroupbyNode) = x -> run(x, g)
+run(input::DataNode, g::GroupbyNode) = run(input.input, g)
 run(df::DataFrames.DataFrame, g::GroupbyNode) = groupby(df, g.fields)

--- a/src/jplyr.jl
+++ b/src/jplyr.jl
@@ -4,9 +4,8 @@ using DataFrames
 export @query,
     @filter,
     @select,
-    @groupby,
+    @groupby
     # following are exported only for test purposes
-    resolve
 
 include("querynode.jl")
 include("query.jl")

--- a/src/querynode.jl
+++ b/src/querynode.jl
@@ -1,30 +1,56 @@
 abstract QueryNode
+abstract QueryHelper
 
-immutable DataNode <: QueryNode
-    input::Symbol
+type DataNode <: QueryNode
+    input
+
+    DataNode() = new()
 end
 
-immutable FilterNode <: QueryNode
+function (::Type{DataNode})(x)
+    res = DataNode()
+    res.input = x
+    return res
+end
+
+type FilterHelper <: QueryHelper
+    kernel
+    fields::Set{Symbol}
+end
+
+type FilterNode <: QueryNode
     input::QueryNode
     conds::Vector{Expr}
+    hlpr::FilterHelper
+
+    FilterNode(input, conds) = new(input, conds)
 end
 
-# FilterNode(input::Symbol, conds) = FilterNode(DataNode(input), conds)
+function (::Type{FilterNode})(input, conds, hlpr)
+    res = FilterNode(input, conds)
+    res.hlpr = hlpr
+    return res
+end
 
 immutable SelectNode <: QueryNode
     input::QueryNode
     fields::Vector{Symbol}
 end
 
-# SelectNode(input::Symbol, cols) = SelectNode(DataNode(input), cols)
-
 immutable GroupbyNode <: QueryNode
     input::QueryNode
     fields::Vector{Symbol}
 end
 
-# GroupbyNode(input::Symbol, cols) = GroupbyNode(DataNode(input), cols)
+immutable CurryNode end
+
+typealias DataSource Union{DataFrames.DataFrame}
 
 for T in (:FilterNode, :SelectNode, :GroupbyNode)
-    @eval $T(input::Symbol, xs) = $T(DataNode(input), xs)
+    @eval (::Type{$T})(input::DataSource, xs...) = $T(DataNode(input), xs...)
 end
+
+has_src(g::QueryNode) = has_src(g.input)
+has_src(g::DataNode) = isdefined(g.input)
+set_src!(g::QueryNode, data) = set_src!(g.input, data)
+set_src!(g::DataNode, data) = (g.input = data; data)


### PR DESCRIPTION
This refactor is motivated primarily by the realization that, in order for graphs produced by `@query` to be `run`able, the base `DataNode` cannot just store a symbol -- it must wrap the data source object itself (be it a `DataFrame`, database connection, etc.). Otherwise, `run`ing the graph will have no ability to access the source (apart from `eval`, but this isn't a viable option for reasons mentioned elsewhere). Thus, at least _some_ of the graph generation must occur at runtime. However, as noted in #1, in order for the graph to be relevant to, say, producing a filtering kernel, it must occur largely at macroexpand-time. This is an issue for both piped to and non-piped to manipulations wrapped in an `@query`. To summarize: the difficulty is that all of the information we wish to contain in the non-base `QueryNode`s (i.e. everything except `DataNode`) is present at macroexpand-time, at which point we would like to generate an appropriate graph, but the information to be contained in the base node (the `DataNode`) is only available at runtime. 

In order to achieve the necessary balance that is becoming apparent in these experiments, this PR makes `DataNode`s mutable -- they can be incompletely initialized and a general `graph` can be given a data source post-generation via `set_src!`. However, this means that the `DataNode` type cannot convey information about the type of its wrapped data source, since that information isn't available at macroexpand time, when the `DataNode` is constructed. It's not clear if this will present an issue, since the content of a `DataNode` will pass through function barriers in the course of `run`ing the query.

This PR also introduces the `FilterHelper` type, which contains the information necessary to perform filtering on a `DataFrame` -- i.e., the filtering kernel and the relevant fields (as symbols). `FilterHelper`s are produced at runtime (have to be, since they wrap the filtering kernel) are contained within `FilterNode`s. The latter in turn are now mutable -- they can be incompletely initialized without `FilterHelper`s. This decision is with an eye towards how filtering kernels will be produced for complex graphs returned by `@query`.

This PR introduces the empty `CurryNode` type whose sole purpose is to clarify the dispatch pattern that produces lambdas for accepting piped data sources in the one-off macros. 

This PR includes other minor changes for the sake of efficiency. For instance, the _command methods (e.g. `_filter`) have been removed and instead the relevant `QueryNode` constructors are called directly.

I apologize to the git deities for doing this all in a single commit. 
