### PR TITLE
Collect graphs produced by at-query

### DIFF
--- a/src/collect.jl
+++ b/src/collect.jl
@@ -1,0 +1,19 @@
+function Base.collect(g::QueryNode)
+    has_src(g) || error()
+    return _collect(g)
+end
+
+_collect(d::DataNode) = d.input
+_collect(g::QueryNode) = _collect(_collect(g.input), g)
+_collect(::CurryNode, g::QueryNode) = x -> _collect(x, g)
+
+# The following are implementations for concrete data sources 
+
+_collect(df::DataFrames.DataFrame, g::SelectNode) = df[g.fields]
+_collect(df::DataFrames.DataFrame, g::GroupbyNode) = groupby(df, g.fields)
+function _collect(df::DataFrames.DataFrame, g::FilterNode)
+    hlpr = g.hlpr
+    cols = [ df[field] for field in hlpr.fields ]
+    rows = bitbroadcast(hlpr.kernel, cols...)
+    return df[rows, :]
+end

--- a/src/filter.jl
+++ b/src/filter.jl
@@ -8,7 +8,7 @@ macro filter(input::Symbol, _conds::Expr...)
         $f = $fdef
         hlpr = FilterHelper($f, $fields)
         g = FilterNode($(esc(input)), $conds, hlpr)
-        return run(g.input, g)
+        run(g)
     end
 end
 
@@ -19,8 +19,8 @@ macro filter(_conds::Expr...)
     return quote
         $f = $fdef
         hlpr = FilterHelper($f, $fields)
-        g = FilterNode(gensym(), $conds, hlpr)
-        return run(CurryNode(), g)
+        g = FilterNode(DataNode(), $conds, hlpr)
+        run(CurryNode(), g)
     end
 end
 

--- a/src/filter.jl
+++ b/src/filter.jl
@@ -8,7 +8,7 @@ macro filter(input::Symbol, _conds::Expr...)
         $f = $fdef
         hlpr = FilterHelper($f, $fields)
         g = FilterNode($(esc(input)), $conds, hlpr)
-        run(g)
+        _collect(g)
     end
 end
 
@@ -20,15 +20,6 @@ macro filter(_conds::Expr...)
         $f = $fdef
         hlpr = FilterHelper($f, $fields)
         g = FilterNode(DataNode(), $conds, hlpr)
-        run(CurryNode(), g)
+        _collect(CurryNode(), g)
     end
-end
-
-run(::CurryNode, g::FilterNode) = x -> run(x, g)
-run(input::DataNode, g::FilterNode) = run(input.input, g)
-function run(df::DataFrames.DataFrame, g::FilterNode)
-    hlpr = g.hlpr
-    cols = [ df[field] for field in hlpr.fields ]
-    rows = bitbroadcast(hlpr.kernel, cols...)
-    return df[rows, :]
 end

--- a/src/groupby.jl
+++ b/src/groupby.jl
@@ -8,21 +8,17 @@ macro groupby(args...)
     return quote
         try # assume first that first arg is data input
             g = GroupbyNode($(esc(input)), collect($cols))
-            run(g.input, g)
+            _collect(g)
         catch err
             #= if error because first arg isn't valid name, assume it is a
-            column specification and return curried run. Otherwise, throw
+            column specification and return curried collect. Otherwise, throw
             the error =#
             if err == UndefVarError($_input)
                 g = GroupbyNode(DataNode(), collect($args))
-                run(CurryNode(), g)
+                _collect(CurryNode(), g)
             else
                 throw(err)
             end
         end
     end
 end
-
-run(::CurryNode, g::GroupbyNode) = x -> run(x, g)
-run(input::DataNode, g::GroupbyNode) = run(input.input, g)
-run(df::DataFrames.DataFrame, g::GroupbyNode) = groupby(df, g.fields)

--- a/src/jplyr.jl
+++ b/src/jplyr.jl
@@ -13,5 +13,6 @@ include("select.jl")
 include("filter.jl")
 include("groupby.jl")
 include("resolve.jl")
+include("collect.jl")
 
 end # module

--- a/src/querynode.jl
+++ b/src/querynode.jl
@@ -32,6 +32,9 @@ function (::Type{FilterNode})(input, conds, hlpr)
     return res
 end
 
+has_hlpr(g::FilterNode) = isdefined(g, :hlpr)
+set_hlpr!(g::FilterNode, hlpr::FilterHelper) = (g.hlpr = hlpr; return hlpr)
+
 immutable SelectNode <: QueryNode
     input::QueryNode
     fields::Vector{Symbol}

--- a/src/querynode.jl
+++ b/src/querynode.jl
@@ -51,6 +51,6 @@ for T in (:FilterNode, :SelectNode, :GroupbyNode)
 end
 
 has_src(g::QueryNode) = has_src(g.input)
-has_src(g::DataNode) = isdefined(g.input)
+has_src(g::DataNode) = isdefined(g, :input)
 set_src!(g::QueryNode, data) = set_src!(g.input, data)
 set_src!(g::DataNode, data) = (g.input = data; data)

--- a/src/resolve.jl
+++ b/src/resolve.jl
@@ -5,17 +5,17 @@ conditions)
 https://gist.github.com/simonbyrne/30522225543b86f3f20e084220c2f485
 =#
 
-function resolve_filter(_conds::Vector{Expr})
-    fields, conds = resolve_conds(_conds)
-    cond = aggr(conds)
-    fdef = Expr(:->, Expr(:tuple, fields...), cond)
+function resolve_filter(conds::Vector{Expr})
+    fields, rconds = resolve_conds(conds)
+    rcond = aggr(rconds)
+    fdef = Expr(:->, Expr(:tuple, fields...), rcond)
     return gensym("f"), fdef, fields
 end
 
-function resolve_conds(_conds)
+function resolve_conds(conds)
     fields = Set{Symbol}()
-    conds = [ resolve!(_cond, fields) for _cond in _conds ]
-    return fields, conds
+    rconds = [ resolve!(cond, fields) for cond in conds ]
+    return fields, rconds
 end
 
 resolve!(x, fields) = x
@@ -26,7 +26,7 @@ end
 
 function resolve!(ex::Expr, fields)
     if ex.head == :$
-        return ex.args[1]
+        return esc(ex.args[1])
     elseif ex.head == :call
         return Expr(:call, exf(ex), [ resolve!(arg, fields) for arg in exfargs(ex) ]...)
     elseif ex.head == :comparison
@@ -36,4 +36,4 @@ function resolve!(ex::Expr, fields)
     end
 end
 
-aggr(conds) = foldl((x,y)->:($x & $y), conds)
+aggr(rconds) = foldl((x,y)->:($x & $y), rconds)

--- a/src/select.jl
+++ b/src/select.jl
@@ -15,21 +15,17 @@ macro select(args...)
     return quote
         try # assume first that first arg is data input
             g = SelectNode($(esc(input)), collect($cols))
-            run(g.input, g)
+            _collect(g)
         catch err
             #= if error because first arg isn't valid name, assume it is a
-            column specification and return curried run. Otherwise, throw
+            column specification and return curried collect. Otherwise, throw
             the error =#
             if err == UndefVarError($_input)
                 g = SelectNode(DataNode(), collect($args))
-                run(CurryNode(), g)
+                _collect(CurryNode(), g)
             else
                 throw(err)
             end
         end
     end
 end
-
-run(::CurryNode, g::SelectNode) = x -> run(x, g)
-run(input::DataNode, g::SelectNode) = run(input.input, g)
-run(df::DataFrames.DataFrame, g::SelectNode) = df[g.fields]


### PR DESCRIPTION
This PR changes the name of `run` to `collect` and exposes an extension of `Base.collect` to the user to use on graphs generated by `@query`. (The internal interface is also consolidated and moved to `src/collect.jl`.) Of course, the only supported data sources as of now are `DataFrame`s, and this support is also implemented in this PR. 

``` julia
julia> q = @query iris |>
           filter(PetalLength > 1.5, Species == "setosa") |>
           select(SepalLength)
# output suppressed because I'm still dragging my feet on implementing show

julia> collect(q)
13×1 DataFrames.DataFrame
│ Row │ SepalLength │
├─────┼─────────────┤
│ 1   │ 5.4         │
│ 2   │ 4.8         │
│ 3   │ 5.7         │
│ 4   │ 5.4         │
│ 5   │ 5.1         │
│ 6   │ 4.8         │
│ 7   │ 5.0         │
│ 8   │ 5.0         │
│ 9   │ 4.7         │
│ 10  │ 4.8         │
│ 11  │ 5.0         │
│ 12  │ 5.1         │
│ 13  │ 5.1         │
```

The main work in providing this support has to do with generating the expressions for defining the filtering kernels and setting the respective `FitlerHelper` objects into their respective `FilterNode`s in the graph.

Right now, we don't do anything to optimize in the case of multiple `filter` calls, e.g.

``` julia
q = @query iris |>
    filter(PetalLength > 1.5, Species == "setosa") |>
    filter(SepalLength > 5.0)
```

But in the future we will hopefully find ways to be smart about how we generate kernel definitions for such cases.
