### PR TITLE
Simplify graph processing machinery

### DIFF
--- a/src/process/crossjoin.jl
+++ b/src/process/crossjoin.jl
@@ -1,4 +1,4 @@
-function process_arg!(node::CrossJoinNode, e)
+function process_arg!(q::CrossJoinNode, e)
     arg_parameters = Set{Symbol}()
 
     lhs, rhs = e.args[1], e.args[2]
@@ -7,19 +7,12 @@ function process_arg!(node::CrossJoinNode, e)
     g_expr, g_arg_fields = build_kernel_ex!(rhs, arg_parameters)
 
     for p in arg_parameters
-        push!(node.parameters, p)
+        push!(q.parameters, p)
     end
     return quote
-        CrossJoinHelper($f_expr, $g_expr, $f_arg_fields, $g_arg_fields)
+        push!(
+            $(q.helpers),
+            CrossJoinHelper($f_expr, $g_expr, $f_arg_fields, $g_arg_fields)
+        )
     end
-end
-
-function _process_node!(q::CrossJoinNode)
-    helpers_ex = Expr(:ref, :CrossJoinHelper)
-    for arg in q.args
-        # TODO: check_arg(arg)
-        helper_ex = process_arg!(q, arg)
-        push!(helpers_ex.args, helper_ex)
-    end
-    return helpers_ex
 end

--- a/src/process/filter.jl
+++ b/src/process/filter.jl
@@ -1,21 +1,10 @@
-function process_arg!(node::FilterNode, filter_pred)
+function process_arg!(q::FilterNode, filter_pred)
     arg_parameters = Set{Symbol}()
     kernel_ex, arg_fields = build_kernel_ex!(filter_pred, arg_parameters)
     for p in arg_parameters
-        push!(node.parameters, p)
+        push!(q.parameters, p)
     end
     return quote
-        FilterHelper($kernel_ex, $arg_fields)
+        push!($(q.helpers), FilterHelper($kernel_ex, $arg_fields))
     end
 end
-
-function _process_node!(g::FilterNode)
-    # TODO: check_node(g)
-    helpers_ex = Expr(:ref, :FilterHelper)
-    filter_pred = aggregate(g.args)
-    helper_ex = process_arg!(g, filter_pred)
-    push!(helpers_ex.args, helper_ex)
-    return helpers_ex
-end
-
-aggregate(args) = foldl((x,y)->:($x & $y), args)

--- a/src/process/generic.jl
+++ b/src/process/generic.jl
@@ -1,32 +1,58 @@
 """
-Processing a graph entails: (i) building `QueryHelper`-creating expressions;
+    process_graph!(g)
+
+Process a `QueryNode` graph by (i) building `QueryHelper`-creating expressions;
 (ii) identifying and processing unbound query parameters.
+
+Returns an expression that mutates each `QueryNode` node of the graph `g` by
 """
 function process_graph!(g)::Expr
-    set_helpers!_ex = Expr(:block)
-    process_node!(g, set_helpers!_ex)
-    return set_helpers!_ex
+    push!_helpers_ex = Expr(:block)
+    process_node!(g, push!_helpers_ex)
+    return push!_helpers_ex
 end
 
 process_node!(g::DataNode, set_helpers!_ex)::Void = nothing
 
 """
+`process_node!(q::QueryNode, set_helpers!_ex)`
+
+Push expressions that generate `QueryHelper`s to the `args` field of
+`set_helpers!_ex`.
+
+Recursively acts on the graph of `QueryNode`s of which `q` is a part.
 """
-function process_node!(q::QueryNode, set_helpers!_ex)::Void
-    helpers_ex = _process_node!(q)
-    push!(set_helpers!_ex.args,
-          :( set_helpers!($q, $helpers_ex) )
-    )
-    process_node!(q.input, set_helpers!_ex)
+function process_node!(q::QueryNode, push!_helpers_ex)::Void
+    # helpers_ex = _process_node!(q)
+    for arg in q.args
+        push!_helper_ex = process_arg!(q, arg)
+        push!(
+            push!_helpers_ex.args,
+            push!_helper_ex
+        )
+    end
+    process_node!(q.input, push!_helpers_ex)
     return
 end
 
-function process_node!(q::JoinNode, set_helpers!_ex)::Void
-    helpers_ex = _process_node!(q)
-    push!(set_helpers!_ex.args,
-          :( set_helpers!($q, $helpers_ex) )
-    )
-    process_node!(q.input1, set_helpers!_ex)
-    process_node!(q.input2, set_helpers!_ex)
+function process_node!(q::JoinNode, push!_helpers_ex)::Void
+    # helpers_ex = _process_node!(q)
+    for arg in q.args
+        push!_helper_ex = process_arg!(q, arg)
+        push!(
+            push!_helpers_ex.args,
+            push!_helper_ex
+        )
+    end
+    process_node!(q.input1, push!_helpers_ex)
+    process_node!(q.input2, push!_helpers_ex)
     return
 end
+
+"""
+    process_arg(q, e)
+
+(i) Return an expression that creates a `QueryHelper` object and (ii) identify
+unbound parameters in `e` and include them into the `parameters` field of `q`.
+"""
+function process_arg end

--- a/src/process/groupby.jl
+++ b/src/process/groupby.jl
@@ -1,5 +1,3 @@
-"""
-"""
 function process_arg!(q::GroupbyNode, arg)
     is_predicate = isa(arg, Expr) ? true : false
     arg_parameters = Set{Symbol}()
@@ -8,19 +6,6 @@ function process_arg!(q::GroupbyNode, arg)
         push!(q.parameters, p)
     end
     return quote
-        GroupbyHelper($is_predicate, $f_expr, $arg_fields)
+        push!($(q.helpers), GroupbyHelper($is_predicate, $f_expr, $arg_fields))
     end
-end
-
-"""
-"""
-function _process_node!(g::GroupbyNode)
-    # TODO: check_node(g)
-    helpers_ex = Expr(:ref, :GroupbyHelper)
-    for arg in g.args
-        # TODO: check_arg(arg)
-        helper_ex = process_arg!(g, arg)
-        push!(helpers_ex.args, helper_ex)
-    end
-    return helpers_ex
 end

--- a/src/process/innerjoin.jl
+++ b/src/process/innerjoin.jl
@@ -1,4 +1,4 @@
-function process_arg!(node::InnerJoinNode, e)
+function process_arg!(q::InnerJoinNode, e)
     arg_parameters = Set{Symbol}()
 
     lhs, rhs = e.args[1], e.args[2]
@@ -7,19 +7,13 @@ function process_arg!(node::InnerJoinNode, e)
     g_expr, g_arg_fields = build_kernel_ex!(rhs, arg_parameters)
 
     for p in arg_parameters
-        push!(node.parameters, p)
+        push!(q.parameters, p)
     end
     return quote
-        InnerJoinHelper($f_expr, $g_expr, $f_arg_fields, $g_arg_fields)
-    end
-end
+        push!(
+            $(q.helpers),
+            InnerJoinHelper($f_expr, $g_expr, $f_arg_fields, $g_arg_fields)
+        )
 
-function _process_node!(q::InnerJoinNode)
-    helpers_ex = Expr(:ref, :InnerJoinHelper)
-    for arg in q.args
-        # TODO: check_arg(arg)
-        helper_ex = process_arg!(q, arg)
-        push!(helpers_ex.args, helper_ex)
     end
-    return helpers_ex
 end

--- a/src/process/leftjoin.jl
+++ b/src/process/leftjoin.jl
@@ -1,4 +1,4 @@
-function process_arg!(node::LeftJoinNode, e)
+function process_arg!(q::LeftJoinNode, e)
     arg_parameters = Set{Symbol}()
 
     lhs, rhs = e.args[1], e.args[2]
@@ -7,19 +7,12 @@ function process_arg!(node::LeftJoinNode, e)
     g_expr, g_arg_fields = build_kernel_ex!(rhs, arg_parameters)
 
     for p in arg_parameters
-        push!(node.parameters, p)
+        push!(q.parameters, p)
     end
     return quote
-        LeftJoinHelper($f_expr, $g_expr, $f_arg_fields, $g_arg_fields)
+        push!(
+            $(q.helpers),
+            LeftJoinHelper($f_expr, $g_expr, $f_arg_fields, $g_arg_fields)
+        )
     end
-end
-
-function _process_node!(q::LeftJoinNode)
-    helpers_ex = Expr(:ref, :LeftJoinHelper)
-    for arg in q.args
-        # TODO: check_arg(arg)
-        helper_ex = process_arg!(q, arg)
-        push!(helpers_ex.args, helper_ex)
-    end
-    return helpers_ex
 end

--- a/src/process/outerjoin.jl
+++ b/src/process/outerjoin.jl
@@ -1,4 +1,4 @@
-function process_arg!(node::OuterJoinNode, e)
+function process_arg!(q::OuterJoinNode, e)
     arg_parameters = Set{Symbol}()
 
     lhs, rhs = e.args[1], e.args[2]
@@ -7,19 +7,12 @@ function process_arg!(node::OuterJoinNode, e)
     g_expr, g_arg_fields = build_kernel_ex!(rhs, arg_parameters)
 
     for p in arg_parameters
-        push!(node.parameters, p)
+        push!(q.parameters, p)
     end
     return quote
-        OuterJoinHelper($f_expr, $g_expr, $f_arg_fields, $g_arg_fields)
+        push!(
+            $(q.helpers),
+            OuterJoinHelper($f_expr, $g_expr, $f_arg_fields, $g_arg_fields)
+        )
     end
-end
-
-function _process_node!(q::OuterJoinNode)
-    helpers_ex = Expr(:ref, :OuterJoinHelper)
-    for arg in q.args
-        # TODO: check_arg(arg)
-        helper_ex = process_arg!(q, arg)
-        push!(helpers_ex.args, helper_ex)
-    end
-    return helpers_ex
 end

--- a/src/process/select.jl
+++ b/src/process/select.jl
@@ -1,38 +1,11 @@
-# function process_arg!(node::SelectNode, e::Symbol)
-#     # TODO: check for query parameters
-#     # arg_parameters = Set{Symbol}()
-#     res_field = QuoteNode(e)
-#     arg_fields = [e]
-#     return quote
-#         SelectHelper($res_field, Base.identity, $arg_fields)
-#     end
-# end
-
-"""
-Processing a `QueryArg` of a `SelectNode` consists of (i) building an
-expression that creates a `SelectHelper` object; and (ii) identifying and
-processing any unbound parameters.
-"""
-function process_arg!(node::SelectNode, e)
+function process_arg!(q::SelectNode, e)::Expr
     arg_parameters = Set{Symbol}()
     res_field, value_expr = result_column(e)
     f_expr, arg_fields = build_kernel_ex!(value_expr, arg_parameters)
     for p in arg_parameters
-        push!(node.parameters, p)
+        push!(q.parameters, p)
     end
     return quote
-        SelectHelper($res_field, $f_expr, $arg_fields)
+        push!($(q.helpers), SelectHelper($res_field, $f_expr, $arg_fields))
     end
-end
-
-"""
-"""
-function _process_node!(q::SelectNode)
-    helpers_ex = Expr(:ref, :SelectHelper)
-    for arg in q.args
-        # TODO: check_arg(arg)
-        helper_ex = process_arg!(q, arg)
-        push!(helpers_ex.args, helper_ex)
-    end
-    return helpers_ex
 end

--- a/src/process/summarize.jl
+++ b/src/process/summarize.jl
@@ -1,5 +1,3 @@
-"""
-"""
 function process_arg!(q::SummarizeNode, arg)::Expr
     res_field = QuoteNode(get_res_field(arg))
     # Extract the first layer, which we assume is the summarization function
@@ -13,22 +11,23 @@ function process_arg!(q::SummarizeNode, arg)::Expr
         push!(q.parameters, p)
     end
     return quote
-        SummarizeHelper($res_field, $f_expr, $(esc(g_name)), $arg_fields)
+        push!(
+            $(q.helpers),
+            SummarizeHelper($res_field, $f_expr, $(esc(g_name)), $arg_fields)
+        )
     end
 end
+#
+# function _process_node!(q::SummarizeNode)::Expr
+#     check_node(q)
+#     helpers_ex = Expr(:ref, :SummarizeHelper)
+#     for arg in q.args
+#         helper_ex = process_arg!(q, arg)
+#         push!(helpers_ex.args, helper_ex)
+#     end
+#     return helpers_ex
+# end
 
-function _process_node!(q::SummarizeNode)::Expr
-    check_node(q)
-    helpers_ex = Expr(:ref, :SummarizeHelper)
-    for arg in q.args
-        helper_ex = process_arg!(q, arg)
-        push!(helpers_ex.args, helper_ex)
-    end
-    return helpers_ex
-end
-
-"""
-"""
 function check_node(g::SummarizeNode)
     for e in g.args
         @assert isa(e, Expr)

--- a/src/query/collect.jl
+++ b/src/query/collect.jl
@@ -1,7 +1,8 @@
 """
     Base.collect(qry::Query{Symbol}; sources...)
 
-`collect` a `Query` object formed by using a placeholder source in a query.
+Collect a `Query` object formed by using a placeholder source in a query.
+
 The symbols used as placeholders in the original `@query` invocation must appear
 as keys in the `sources...` keyword arguments. Each respective value should be
 the source that will be substituded for the symbol placeholder when the `Query`
@@ -40,6 +41,8 @@ end
 
 """
     Base.collect(source, graph::QueryNode)
+
+Collect a query `graph` against a data `source`.
 
 This method has two purposes. The first is to dispatch to the
 appropriate `collect` machinery. (The default collection machinery is

--- a/src/query/macros.jl
+++ b/src/query/macros.jl
@@ -20,9 +20,9 @@ end
 macro collect(qry)
     src, g = gen_graph(qry)
     set_helpers!_ex = process_graph!(g)
-    if isempty(src) # if we found a placeholder source (designated by a symbol)
+    if isempty(src)
         src_name = QuoteNode(source(g))
-    else # otherwise, there's an actual source
+    else
         src_name = src[1]
     end
     return quote

--- a/src/querynode/typedefs.jl
+++ b/src/querynode/typedefs.jl
@@ -24,7 +24,7 @@ end
 
 """
 """
-type SelectNode <: QueryNode
+immutable SelectNode <: QueryNode
     input::QueryNode
     args::Vector{QueryArg}
     helpers::Vector{SelectHelper}
@@ -37,7 +37,7 @@ end
 
 """
 """
-type FilterNode <: QueryNode
+immutable FilterNode <: QueryNode
     input::QueryNode
     args::Vector{QueryArg}
     helpers::Vector{FilterHelper}
@@ -50,7 +50,7 @@ end
 
 """
 """
-type GroupbyNode <: QueryNode
+immutable GroupbyNode <: QueryNode
     input::QueryNode
     args::Vector{QueryArg}
     helpers::Vector{GroupbyHelper}
@@ -63,7 +63,7 @@ end
 
 """
 """
-type SummarizeNode <: QueryNode
+immutable SummarizeNode <: QueryNode
     input::QueryNode
     args::Vector{QueryArg}
     helpers::Vector{SummarizeHelper}
@@ -76,7 +76,7 @@ end
 
 """
 """
-type OrderbyNode <: QueryNode
+immutable OrderbyNode <: QueryNode
     input::QueryNode
     args::Vector{QueryArg}
     helpers::Vector{SummarizeHelper}
@@ -91,7 +91,7 @@ end
 
 """
 """
-type LeftJoinNode <: JoinNode
+immutable LeftJoinNode <: JoinNode
     input1::QueryNode
     input2::QueryNode
     args::Vector{QueryArg}
@@ -105,7 +105,7 @@ end
 
 """
 """
-type OuterJoinNode <: JoinNode
+immutable OuterJoinNode <: JoinNode
     input1::QueryNode
     input2::QueryNode
     args::Vector{QueryArg}
@@ -119,7 +119,7 @@ end
 
 """
 """
-type InnerJoinNode <: JoinNode
+immutable InnerJoinNode <: JoinNode
     input1::QueryNode
     input2::QueryNode
     args::Vector{QueryArg}
@@ -133,7 +133,7 @@ end
 
 """
 """
-type CrossJoinNode <: JoinNode
+immutable CrossJoinNode <: JoinNode
     input1::QueryNode
     input2::QueryNode
     args::Vector{QueryArg}


### PR DESCRIPTION
This PR simplifies the graph processing machinery by which `QueryHelper` objects are generated. As a result of these changes, non-base `QueryNode` objects (i.e. everything except `DataNode`s) can be made `immutable`, a change that is also introduced here. 
