### PR TITLE
Support query composition

### DIFF
--- a/src/query/graph/graph.jl
+++ b/src/query/graph/graph.jl
@@ -16,8 +16,12 @@ const QUERYNODE = Dict{Symbol, Tuple{DataType, DataType}}(
     :crossjoin => (CrossJoinNode, CrossJoinHelper)
 )
 
+_leaf(x) = DataNode(x)
+_leaf(q::Query) = q.graph
+
 gen_graph_ex(qry) = gen_graph_ex(qry, false)
-gen_graph_ex(src::Symbol, piped_to) = Expr(:call, :DataNode, esc(src))
+gen_graph_ex(src::Symbol, piped_to) =
+    Expr(:call, :(StructuredQueries._leaf), esc(src))
 
 function gen_graph_ex(ex::Expr, piped_to)
     if ex.head == :call

--- a/src/query/show.jl
+++ b/src/query/show.jl
@@ -1,3 +1,3 @@
-function Base.show(io::IO, qry::Query)::Void
-    print(io, "A Query.")
+function Base.show(io::IO, q::Query)::Void
+    @printf(io, "Query against a source of type %s", typeof(source(q)))
 end

--- a/test/query/query.jl
+++ b/test/query/query.jl
@@ -6,8 +6,9 @@ using Base.Test
 io = IOBuffer()
 disp = TextDisplay(IOBuffer())
 
-type MyData end
+immutable MyData end
 src = MyData()
+_src = MyData()
 
 n = 10
 A = rand(n)
@@ -123,6 +124,17 @@ display(disp, q_a)
 
 q_a = @query crossjoin(src1, src2, A = B)
 q_b = @query src1 |> crossjoin(src2, A = B)
+@test isequal(q_a, q_b)
+show(io, q_a)
+display(disp, q_a)
+
+##################
+# querying a Query
+
+f(q::Query) = @query q |> select(B)
+q_a = f(@query filter(src, A > .5))
+q_b = @query filter(src, A > .5) |> select(B)
+@test isequal(src, _src)
 @test isequal(q_a, q_b)
 show(io, q_a)
 display(disp, q_a)


### PR DESCRIPTION
It was noted in [this discussion](https://twitter.com/johnmyleswhite/status/783324359821631488) that dummy sources could be replaced by functions, so long as one can compose `Query`s by means of the `@query` macro. This PR introduces that functionality:

``` julia
julia> df = DataFrame()
0×0 DataFrames.DataFrame


julia> f(q::Query) = @query q |> select(A)
f (generic function with 1 method)

julia> f(@query filter(df, A > .5))
Query against a source of type 0×0 DataFrames.DataFrame


julia> ans.graph
SelectNode
  arguments:
      1)  A
  inputs:
      1)  FilterNode
            arguments:
                1)  A > 0.5
            inputs:
                1)  DataNode
                      source:  source of type DataFrame
```

EDIT: c.f. https://github.com/davidagold/StructuredQueries.jl/issues/20
